### PR TITLE
chore: stub metro import locations plugin for expo

### DIFF
--- a/metro-import-locations-plugin.js
+++ b/metro-import-locations-plugin.js
@@ -1,0 +1,13 @@
+function importLocationsPlugin() {
+  return {
+    visitor: {}
+  };
+}
+
+function locToKey(loc) {
+  if (!loc) return '';
+  const { start, end } = loc;
+  return `${start.line}:${start.column}-${end.line}:${end.column}`;
+}
+
+module.exports = { importLocationsPlugin, locToKey };

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,5 +1,13 @@
+const path = require('path');
+const Module = require('module');
+const originalResolveFilename = Module._resolveFilename;
+Module._resolveFilename = function (request, parent, isMain, options) {
+  if (request === 'metro/src/ModuleGraph/worker/importLocationsPlugin') {
+    return path.join(__dirname, 'metro-import-locations-plugin.js');
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
 const { getDefaultConfig } = require('expo/metro-config');
-
 const config = getDefaultConfig(__dirname);
-
 module.exports = config;


### PR DESCRIPTION
## Summary
- provide stub `importLocationsPlugin` to satisfy expo's metro config
- patch metro module resolution to use local plugin

## Testing
- `npm run dev` *(fails: TypeError: fetch failed)*
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6890ca46299c8328ac8d4bd617250722