### PR TITLE
chore: pin metro dependencies for expo

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
+    "metro": "^0.81.0",
+    "metro-config": "^0.81.0",
+    "metro-runtime": "^0.81.0",
     "typescript": "~5.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- add explicit metro@^0.81.0 and related packages to devDependencies

## Testing
- `npm install --no-progress --no-audit` *(fails: 403 Forbidden - GET https://registry.npmjs.org/metro-config)*
- `npm run lint` *(fails: ESLint is not configured for this project)*
- `npm run dev` *(fails: Cannot find module 'metro/src/ModuleGraph/worker/importLocationsPlugin')*


------
https://chatgpt.com/codex/tasks/task_e_6890ce6bf37c8328860e6c137c18614c