### PR TITLE
fix: quote font weight

### DIFF
--- a/app/+not-found.tsx
+++ b/app/+not-found.tsx
@@ -24,7 +24,7 @@ const styles = StyleSheet.create({
   },
   text: {
     fontSize: 20,
-    fontWeight: 600,
+    fontWeight: '600',
   },
   link: {
     marginTop: 15,


### PR DESCRIPTION
## Summary
- quote `fontWeight` in not found screen text style to a string

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_6890d1042f588328b69a29c46415c142