### PR TITLE
Track new record before updating high score

### DIFF
--- a/components/game/GameContainer.tsx
+++ b/components/game/GameContainer.tsx
@@ -19,6 +19,7 @@ export default function GameContainer() {
   const [coins, setCoins] = useState(0);
   const [distance, setDistance] = useState(0);
   const [highScore, setHighScore] = useState(0);
+  const [isNewRecord, setIsNewRecord] = useState(false);
   
   const gameLoopRef = useRef<number>();
   const lastTimeRef = useRef<number>(0);
@@ -43,8 +44,11 @@ export default function GameContainer() {
     if (gameLoopRef.current) {
       cancelAnimationFrame(gameLoopRef.current);
     }
-    
-    if (score > highScore) {
+
+    const newRecord = score > highScore;
+    setIsNewRecord(newRecord);
+
+    if (newRecord) {
       setHighScore(score);
     }
   };
@@ -152,7 +156,7 @@ export default function GameContainer() {
           coins={coins}
           distance={Math.floor(distance)}
           highScore={highScore}
-          isNewRecord={score > highScore}
+          isNewRecord={isNewRecord}
           onRestart={restartGame}
         />
       )}


### PR DESCRIPTION
## Summary
- track whether score beats previous high score before updating the value
- pass new record state to GameOverScreen instead of recomputing

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: fetch failed)


------
https://chatgpt.com/codex/tasks/task_e_6890d1057b908328a5a9efd87f044616