### PR TITLE
Add GamePhysics velocity limit tests

### DIFF
--- a/components/game/utils/GamePhysics.test.ts
+++ b/components/game/utils/GamePhysics.test.ts
@@ -1,0 +1,28 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { GamePhysics } from './GamePhysics';
+import { GameConfig } from '../types/GameTypes';
+
+describe('GamePhysics.limitVelocity', () => {
+  it('caps velocity above MAX_VELOCITY', () => {
+    const overMax = GameConfig.MAX_VELOCITY + 10;
+    const limited = GamePhysics.limitVelocity(overMax);
+    assert.strictEqual(limited, GameConfig.MAX_VELOCITY);
+  });
+
+  it('caps velocity below negative MAX_VELOCITY', () => {
+    const belowMin = -GameConfig.MAX_VELOCITY - 10;
+    const limited = GamePhysics.limitVelocity(belowMin);
+    assert.strictEqual(limited, -GameConfig.MAX_VELOCITY);
+  });
+
+  it('returns velocity within limits unchanged', () => {
+    const insideMax = GameConfig.MAX_VELOCITY - 1;
+    const limitedPositive = GamePhysics.limitVelocity(insideMax);
+    assert.strictEqual(limitedPositive, insideMax);
+
+    const insideMin = -GameConfig.MAX_VELOCITY + 1;
+    const limitedNegative = GamePhysics.limitVelocity(insideMin);
+    assert.strictEqual(limitedNegative, insideMin);
+  });
+});

--- a/components/game/utils/GamePhysics.ts
+++ b/components/game/utils/GamePhysics.ts
@@ -1,4 +1,4 @@
-import { GameConfig } from '@/components/game/types/GameTypes';
+import { GameConfig } from '../types/GameTypes';
 
 export class GamePhysics {
   static applyGravity(velocity: number, deltaTime: number): number {


### PR DESCRIPTION
## Summary
- add unit tests for `GamePhysics.limitVelocity` ensuring outputs are capped
- use relative import for `GameConfig` in `GamePhysics` to support tests

## Testing
- `tsc -p tsconfig.test.json`
- `node --test build-test/utils/GamePhysics.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6890d1088a988328a69022b318a59ff1