### PR TITLE
Add touch controls, obstacles and fix jetpack flame alignment

### DIFF
--- a/components/game/components/Player.tsx
+++ b/components/game/components/Player.tsx
@@ -1,10 +1,8 @@
 import React from 'react';
-import { View, StyleSheet, Dimensions } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { LinearGradient } from 'expo-linear-gradient';
 import JetpackFlame from '@/components/game/components/JetpackFlame';
-
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
 interface PlayerProps {
   animatedStyle: any;
@@ -52,13 +50,12 @@ export default function Player({ animatedStyle, isJetpackActive }: PlayerProps) 
 const styles = StyleSheet.create({
   container: {
     position: 'absolute',
-    left: 50,
     zIndex: 3,
   },
   flameContainer: {
     position: 'absolute',
-    bottom: -30,
-    left: 10,
+    bottom: -35,
+    left: 15,
     zIndex: -1,
   },
   player: {

--- a/components/game/screens/GameScreen.tsx
+++ b/components/game/screens/GameScreen.tsx
@@ -4,6 +4,7 @@ import ParallaxBackground from '@/components/game/screens/ParallaxBackground';
 import Player from '@/components/game/components/Player';
 import GameHUD from '@/components/game/components/GameHUD';
 import { GameProps } from '@/components/game/types/GameTypes';
+import Obstacle from '@/components/game/components/Obstacle';
 
 const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 
@@ -14,13 +15,17 @@ export default function GameScreen({
   coins,
   distance,
   isJetpackActive,
+  obstacles,
 }: GameProps) {
   return (
     <View style={styles.container}>
       <ParallaxBackground scrollOffset={scrollOffset} />
-      
+
       <View style={styles.gameArea}>
-        <Player 
+        {obstacles.map(obstacle => (
+          <Obstacle key={obstacle.id} obstacle={obstacle} />
+        ))}
+        <Player
           animatedStyle={playerAnimatedStyle}
           isJetpackActive={isJetpackActive}
         />

--- a/components/game/types/GameTypes.ts
+++ b/components/game/types/GameTypes.ts
@@ -30,10 +30,12 @@ export const GameConfig = {
   GRAVITY: 800,
   JETPACK_FORCE: 1200,
   SCROLL_SPEED: 200,
+  HORIZONTAL_SPEED: 300,
   PLAYER_SIZE: 60,
   COIN_SIZE: 30,
   MAX_VELOCITY: 15,
   OBSTACLE_SPAWN_RATE: 0.02,
+  OBSTACLE_SPEED: 150,
   COIN_SPAWN_RATE: 0.03,
 };
 
@@ -44,4 +46,5 @@ export interface GameProps {
   coins: number;
   distance: number;
   isJetpackActive: any;
+  obstacles: Obstacle[];
 }


### PR DESCRIPTION
## Summary
- Enable drag and side-tap controls for jetpack thrust and horizontal movement
- Align jetpack flame beneath player and follow its position
- Introduce downward scrolling obstacles to avoid

## Testing
- `npm run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_6890dd411d3883288697d192424d951d