### PR TITLE
Reset velocity when jetpack released

### DIFF
--- a/components/game/GameContainer.tsx
+++ b/components/game/GameContainer.tsx
@@ -268,6 +268,8 @@ export default function GameContainer() {
     })
     .onEnd(() => {
       isJetpackActive.value = false;
+      // Reset upward velocity so gravity takes effect immediately
+      playerVelocity.value = Math.max(playerVelocity.value, 0);
     });
 
   const tapGesture = Gesture.Tap()
@@ -280,6 +282,8 @@ export default function GameContainer() {
     .onTouchesUp(() => {
       controlDirection.value = 0;
       isJetpackActive.value = false;
+      // Reset upward velocity when jetpack is released
+      playerVelocity.value = Math.max(playerVelocity.value, 0);
     });
 
   const combinedGesture = Gesture.Race(panGesture, tapGesture);


### PR DESCRIPTION
## Summary
- Reset upward velocity when jetpack input ends so gravity pulls the player down immediately

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: fetch failed while configuring ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_689104fa93c08328a13d7d54cbc87144