### PR TITLE
refactor: animate coins and obstacles independently

### DIFF
--- a/components/game/components/Coin.tsx
+++ b/components/game/components/Coin.tsx
@@ -19,32 +19,28 @@ export default function Coin({ coin }: CoinProps) {
   const scale = useSharedValue(1);
 
   useEffect(() => {
-    rotation.value = withRepeat(
-      withTiming(360, { duration: 2000 }),
-      -1,
-      false
-    );
-    
+    rotation.value = withRepeat(withTiming(360, { duration: 2000 }), -1, false);
+
     scale.value = withRepeat(
       withSequence(
         withTiming(1.1, { duration: 800 }),
-        withTiming(1, { duration: 800 })
+        withTiming(1, { duration: 800 }),
       ),
       -1,
-      true
+      true,
     );
   }, []);
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [
-      { translateX: coin.x },
-      { translateY: coin.y },
+      { translateX: coin.x.value },
+      { translateY: coin.y.value },
       { rotate: `${rotation.value}deg` },
       { scale: scale.value },
     ],
   }));
 
-  if (coin.collected) {
+  if (coin.collected.value) {
     return null;
   }
 

--- a/components/game/components/Obstacle.tsx
+++ b/components/game/components/Obstacle.tsx
@@ -21,15 +21,15 @@ export default function Obstacle({ obstacle }: ObstacleProps) {
       rotation.value = withRepeat(
         withTiming(360, { duration: 1000 }),
         -1,
-        false
+        false,
       );
     }
   }, [obstacle.type]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [
-      { translateX: obstacle.x },
-      { translateY: obstacle.y },
+      { translateX: obstacle.x.value },
+      { translateY: obstacle.y.value },
       { rotate: `${rotation.value}deg` },
     ],
   }));
@@ -40,7 +40,10 @@ export default function Obstacle({ obstacle }: ObstacleProps) {
         return (
           <LinearGradient
             colors={['#666666', '#333333']}
-            style={[styles.platform, { width: obstacle.width, height: obstacle.height }]}
+            style={[
+              styles.platform,
+              { width: obstacle.width, height: obstacle.height },
+            ]}
           />
         );
       case 'blade':

--- a/components/game/screens/GameScreen.tsx
+++ b/components/game/screens/GameScreen.tsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { View, StyleSheet, Dimensions } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import ParallaxBackground from '@/components/game/screens/ParallaxBackground';
 import Player from '@/components/game/components/Player';
 import GameHUD from '@/components/game/components/GameHUD';
 import { GameProps } from '@/components/game/types/GameTypes';
 import Obstacle from '@/components/game/components/Obstacle';
 import Coin from '@/components/game/components/Coin';
-
-const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } = Dimensions.get('window');
 
 export default function GameScreen({
   playerAnimatedStyle,
@@ -24,10 +22,10 @@ export default function GameScreen({
       <ParallaxBackground scrollOffset={scrollOffset} />
 
       <View style={styles.gameArea}>
-        {obstacles.map(obstacle => (
+        {obstacles.value.map((obstacle) => (
           <Obstacle key={obstacle.id} obstacle={obstacle} />
         ))}
-        {coinsList.map(coin => (
+        {coinsList.value.map((coin) => (
           <Coin key={coin.id} coin={coin} />
         ))}
         <Player
@@ -35,12 +33,8 @@ export default function GameScreen({
           isJetpackActive={isJetpackActive}
         />
       </View>
-      
-      <GameHUD 
-        score={score}
-        coins={coins}
-        distance={distance}
-      />
+
+      <GameHUD score={score} coins={coins} distance={distance} />
     </View>
   );
 }

--- a/components/game/types/GameTypes.ts
+++ b/components/game/types/GameTypes.ts
@@ -1,21 +1,22 @@
 export type GameState = 'start' | 'playing' | 'paused' | 'gameOver';
 
+import type { SharedValue } from 'react-native-reanimated';
+
 export interface Obstacle {
   id: string;
   type: 'platform' | 'blade' | 'laser' | 'bird';
-  x: number;
-  y: number;
+  x: SharedValue<number>;
+  y: SharedValue<number>;
   width: number;
   height: number;
   speed?: number;
-  rotation?: number;
 }
 
 export interface Coin {
   id: string;
-  x: number;
-  y: number;
-  collected: boolean;
+  x: SharedValue<number>;
+  y: SharedValue<number>;
+  collected: SharedValue<boolean>;
 }
 
 export interface PowerUp {
@@ -59,7 +60,7 @@ export interface GameProps {
   coins: number;
   distance: number;
   isJetpackActive: any;
-  obstacles: Obstacle[];
+  obstacles: SharedValue<Obstacle[]>;
   // Coins currently on screen
-  coinsList: Coin[];
+  coinsList: SharedValue<Coin[]>;
 }


### PR DESCRIPTION
## Summary
- use shared values for coin and obstacle positions
- update game loop to spawn and move items without React state
- render coins and obstacles as isolated animated components

## Testing
- `npm run lint` (fails: fetch failed)
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68914404768c8328a7e2fb414c2ade33